### PR TITLE
Check for valid JSON content in addition to mime type

### DIFF
--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -26,8 +26,8 @@ function Main() {
 
   const requestFinishedHandler = useCallback(
     (harRequest: chrome.devtools.network.Request) => {
-      if (!isValidRequest(harRequest)) return;
       async function getCurrentTab() {
+        if (!await isValidRequest(harRequest)) return;
         try {
           harRequest.getContent((content) => {
             try {


### PR DESCRIPTION
Some site like this: https://bmtcwebportal.amnex.com/commuter/dashboard does not have mime type set to JSON but they still have the content of API response as JSON.

Here I am additionally adding condition to validate in case the mime type is not JSON, we validate that the response body also is not JSON.