### PR TITLE
Ensure securitySchemes auth names are formatted without whitespaces

### DIFF
--- a/src/lib/endpoints-to-oai31.helpers.ts
+++ b/src/lib/endpoints-to-oai31.helpers.ts
@@ -169,5 +169,5 @@ export const createQueryParameterTypes = (
 
 // Format THIS_TXT_STR to this text str
 export const formatAuthType = (str: string) => {
-  return str.replace(/_/g, " ").toLowerCase();
+  return str.toLowerCase();
 };

--- a/src/lib/endpoints-to-oai31.test.ts
+++ b/src/lib/endpoints-to-oai31.test.ts
@@ -140,17 +140,17 @@ it("sets api keys from headers", () => {
   const endpoints = store.endpoints();
   const oai31 = endpointsToOAI31(endpoints, defaultOptions);
   expect(oai31.rootDoc.components?.securitySchemes).toEqual({
-    [formatAuthType(AuthType.APIKEY_COOKIE_ + "SESSIONID")]: {
+    [`${AuthType.APIKEY_COOKIE_.toLowerCase()}sessionid`]: {
       in: "cookie",
       name: "sessionid",
       type: "apiKey",
     },
-    [formatAuthType(AuthType.APIKEY_HEADER_ + "COOKIE")]: {
+    [`${AuthType.APIKEY_HEADER_.toLowerCase()}cookie`]: {
       in: "header",
       name: "COOKIE",
       type: "apiKey",
     },
-    [formatAuthType(AuthType.APIKEY_HEADER_ + "X-API-KEY")]: {
+    [`${AuthType.APIKEY_HEADER_.toLowerCase()}x-api-key`]: {
       in: "header",
       name: "X-API-KEY",
       type: "apiKey",


### PR DESCRIPTION
Fixes https://github.com/AndrewWalsh/openapi-devtools/issues/15.

`securitySchemes` names currently use whitespace. They now match the expected regular expression.